### PR TITLE
Update ssizePropCI.R

### DIFF
--- a/R/ssizePropCI.R
+++ b/R/ssizePropCI.R
@@ -1,5 +1,5 @@
 ssize.propCI <- function(prop, width, conf.level = 0.95,  method = "wald-cc"){
-  METHODS <- c("wald", "wald-cc")
+  METHODS <- c("wald", "wald-cc", "jeffreys", "clopper-pearson", "wilson", "agresti-coull")
   method <- pmatch(method, METHODS)
   
   if (is.na(method))
@@ -15,6 +15,18 @@ ssize.propCI <- function(prop, width, conf.level = 0.95,  method = "wald-cc"){
     z.alpha <- qnorm(1-alpha/2)
     TERM <- 2*sqrt(width*prop*(1-prop)*z.alpha^2 + prop^2*(1-prop)^2*z.alpha^4)/width^2
     n <- 2*prop*(1-prop)*z.alpha^2/width^2 + 1/width + TERM
+  }
+if(method == 3){ # jeffreys
+    n <- 4*qnorm(1-alpha/2)^2*prop*(1-prop)/width^2
+  }
+if(method == 4){ # clopper-pearson
+    n <- ceiling((2*qnorm(1-alpha/2)^2*prop*(1-prop)+2*qnorm(1-alpha/2)*sqrt(qnorm(1-alpha/2)^2*prop^2*(1-prop)^2+width*prop*(1-prop))+width)/width^2)
+  }
+if(method == 5){ # wilson
+    n <- qnorm(1-alpha/2)^2*(prop*(1-prop)+width^2/2+sqrt(prop^2*(1-prop)^2+width^2*(prop-0.5)^2))/(width^2/2)
+  }
+if(method == 6){ # agresti-coull
+    n <- 4*qnorm(1-alpha/2)^2*prop*(1-prop)/width^2-qnorm(1-alpha/2)^2
   }
   METHOD <- paste("Sample size calculation by method of", METHODS[method])
   NOTE <- "Two-sided confidence interval"


### PR DESCRIPTION
It would be great to add formulas for some of the other intervals available in MKinfer::binomCI. I've added formulas for the Jeffreys, Wilson and Agresti-Coull intervals from Piegorsch (2004) and a Clopper-Pearson formula from a paper of mine, Thulin (2014).

References:
Piegorsch, W.W. (2004). Sample sizes for improved binomial confidence intervals. Computational Statistics & Data Analysis, 46, 309–316.
Thulin, M. (2014). The cost of using exact confidence intervals for a binomial proportion. Electronic Journal of Statistics, 8(1), 817-840.