### PR TITLE
adjusted mu parameter for row_wilcoxon_twosample tests from matrixTests

### DIFF
--- a/R/simPowerTTest.R
+++ b/R/simPowerTTest.R
@@ -26,24 +26,24 @@ sim.power.t.test <- function(nx, rx, rx.H0 = NULL, ny, ry, ry.H0 = NULL,
   }
   ## classical 2-sample t-test
   res <- row_t_equalvar(data.x, data.y, 
-                        alternative = alternative, mu = mu, 
+                        alternative = alternative, null = mu, 
                         conf.level = conf.level)
   if(!is.null(rx.H0) & !is.null(ry.H0)){
     res.H0 <- row_t_equalvar(data.x.H0, data.y.H0, 
                              alternative = alternative, 
-                             mu = mu, conf.level = conf.level)
+                             null = mu, conf.level = conf.level)
     CLASSICAL <- list("H1" = res, "H0" = res.H0)
   }else{
     CLASSICAL <- list("H1" = res)  
   }
   ## Welch t-test
   res <- row_t_welch(data.x, data.y, 
-                     alternative = alternative, mu = mu, 
+                     alternative = alternative, null = mu, 
                      conf.level = conf.level)
   if(!is.null(rx.H0) & !is.null(ry.H0)){
     res.H0 <- row_t_welch(data.x.H0, data.y.H0, 
                           alternative = alternative, 
-                          mu = mu, conf.level = conf.level)
+                          null = mu, conf.level = conf.level)
     WELCH <- list("H1" = res, "H0" = res.H0)
   }else{
     WELCH <- list("H1" = res)

--- a/R/simPowerWilcoxTest.R
+++ b/R/simPowerWilcoxTest.R
@@ -58,7 +58,7 @@ sim.power.wilcox.test <- function(nx, rx, rx.H0 = NULL, ny, ry, ry.H0 = NULL,
       res <- data.frame(t(apply(data.xy, 1, wfun, nx, ny, alternative, 
                                 conf.level, "exact", conf.int = FALSE)))
     }else{
-      res <- row_wilcoxon_twosample(data.x, data.y, alternative, mu = 0, 
+      res <- row_wilcoxon_twosample(data.x, data.y, alternative, null = 0, 
                                     exact = TRUE)
     }
   }
@@ -73,7 +73,7 @@ sim.power.wilcox.test <- function(nx, rx, rx.H0 = NULL, ny, ry, ry.H0 = NULL,
                                      conf.level, "exact", conf.int = FALSE)))
       }else{
         res.H0 <- row_wilcoxon_twosample(data.x.H0, data.y.H0, alternative, 
-                                         mu = 0, exact = TRUE)
+                                         null = 0, exact = TRUE)
       }
       
     }
@@ -86,7 +86,7 @@ sim.power.wilcox.test <- function(nx, rx, rx.H0 = NULL, ny, ry, ry.H0 = NULL,
     res <- data.frame(t(apply(data.xy, 1, wfun, nx, ny, alternative, 
                               conf.level, "asymptotic")))
   }else{
-    res <- row_wilcoxon_twosample(data.x, data.y, alternative, mu = 0, 
+    res <- row_wilcoxon_twosample(data.x, data.y, alternative, null = 0, 
                                   exact = FALSE)
   }
   if(!is.null(rx.H0) & !is.null(ry.H0)){
@@ -95,7 +95,7 @@ sim.power.wilcox.test <- function(nx, rx, rx.H0 = NULL, ny, ry, ry.H0 = NULL,
                                    conf.level, "asymptotic")))
     }else{
       res.H0 <- row_wilcoxon_twosample(data.x.H0, data.y.H0, alternative, 
-                                       mu = 0, exact = FALSE)
+                                       null = 0, exact = FALSE)
     }
     ASYMPTOTIC <- list("H1" = res, "H0" = res.H0)
   }else{

--- a/R/simSsizeWilcoxTest.R
+++ b/R/simSsizeWilcoxTest.R
@@ -33,7 +33,7 @@ sim.ssize.wilcox.test <- function(rx, ry = NULL, mu = 0, sig.level = 0.05, power
       data.x <- matrix(rx(ns[i]*iter), nrow = iter)
       data.y <- matrix(ry(ns[i]*iter), nrow = iter)
       res <- row_wilcoxon_twosample(data.x, data.y, 
-                                    alternative = alternative, mu = mu,
+                                    alternative = alternative, null = mu,
                                     exact = NA, correct = TRUE)[,"pvalue"]
       empPower[i] <- sum(res < sig.level)/iter
       if(empPower[i] > power) if(BREAK) break
@@ -45,7 +45,7 @@ sim.ssize.wilcox.test <- function(rx, ry = NULL, mu = 0, sig.level = 0.05, power
     empPower <- numeric(length(ns))
     for(i in seq_len(length(ns))){
       data.x <- matrix(rx(ns[i]*iter), nrow = iter)
-      res <- row_wilcoxon_onesample(data.x, alternative = alternative, mu = mu,
+      res <- row_wilcoxon_onesample(data.x, alternative = alternative, null = mu,
                                     exact = NA, correct = TRUE)[,"pvalue"]
       empPower[i] <- sum(res < sig.level)/iter
       if(empPower[i] > power) if(BREAK) break
@@ -58,7 +58,7 @@ sim.ssize.wilcox.test <- function(rx, ry = NULL, mu = 0, sig.level = 0.05, power
     for(i in seq_len(length(ns))){
       data.xy <- matrix(rx(ns[i]*iter), nrow = iter)
       res <- row_wilcoxon_onesample(data.xy, 
-                                    alternative = alternative, mu = mu,
+                                    alternative = alternative, null = mu,
                                     exact = NA, correct = TRUE)[,"pvalue"]
       empPower[i] <- sum(res < sig.level)/iter
       if(empPower[i] > power) if(BREAK) break


### PR DESCRIPTION
matrixTests version 0.2. is currently on it's way to [CRAN](https://cran.r-project.org/incoming/pretest/?C=M;O=A)

It has one breaking change - arguments that before were named "mu", "ratio", "null", etc. are now consistently named "null".
Hence, it affects the functions in MKpower package breaking `sim.power.wilcox.test()` and `sim.ssize.wilcox.test()`.

This pull request renames all instances of `mu = ` arguments with `null = ` arguments. I double checked and the examples for the two functions completed without any errors after this change.

Really sorry for the inconvenience.